### PR TITLE
Allow Homarus to generate PNG audio thumbnails

### DIFF
--- a/Homarus/cfg/config.example.yaml
+++ b/Homarus/cfg/config.example.yaml
@@ -11,6 +11,7 @@ homarus:
       - audio/mpeg
       - audio/aac
       - image/jpeg
+      - image/png
     default: video/mp4
   mime_to_format:
     valid:
@@ -21,6 +22,7 @@ homarus:
       - audio/mpeg_mp3
       - audio/aac_m4a
       - image/jpeg_image2pipe
+      - image/png_image2pipe
     default: mp4
 
 fedora_resource:


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora-CLAW/CLAW/issues/1298

# What does this Pull Request do?

Allow Homarus to generate PNG audio thumbnails by adding `image/png` as allowable request content type and `image/png_image2pipe` as output target.

# What's new?
Homarus can generate jpeg thumbnails. This allows PNG thumbnails, as specified for thumbnailing of audio files.

# How should this be tested?

* Apply this config to Homarus: `/var/www/html/Crayfish/Homarus/cfg/config.yaml`
* Add 'Audio - Generate a thumbnail from an original file' action from https://github.com/Islandora-CLAW/CLAW/issues/1298
* Create a repository item with model=Audio, and Audio media with Use=Original file and upload a `.mp3` or `.wav` file.
* In Content administration, check the checkbox for the audio item, then select the action 'Audio - Generate a thumbnail from an original file' and click 'Apply to selected items' button.
* Check the Media tab for the audio repository item, you should see a new media with Use=Thumbnail Image with a related PNG file representing the waveform (black waveform on white background).

# Interested parties
@Islandora-CLAW/committers