### PR TITLE
Adding `-loglevel error` for large files

### DIFF
--- a/Gemini/tests/Islandora/Gemini/Tests/UrlMinterTest.php
+++ b/Gemini/tests/Islandora/Gemini/Tests/UrlMinterTest.php
@@ -12,7 +12,6 @@ use Islandora\Gemini\UrlMinter\UrlMinter;
 class UrlMinterTest extends \PHPUnit_Framework_TestCase
 {
     /**
-     * @covers ::__construct
      * @covers ::mint
      * @expectedException \InvalidArgumentException
      * @expectedExceptionCode 400
@@ -24,7 +23,6 @@ class UrlMinterTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers ::__construct
      * @covers ::mint
      * @expectedException \InvalidArgumentException
      * @expectedExceptionCode 400
@@ -36,7 +34,6 @@ class UrlMinterTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers ::__construct
      * @covers ::mint
      */
     public function testHandlesMissingTrailingSlashInBaseUrl()
@@ -54,7 +51,6 @@ class UrlMinterTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers ::__construct
      * @covers ::mint
      */
     public function testMintsUrlWithPairTrees()

--- a/Homarus/src/Controller/HomarusController.php
+++ b/Homarus/src/Controller/HomarusController.php
@@ -123,16 +123,16 @@ class HomarusController
         // Arguments to ffmpeg command are sent as a custom header.
         $args = $request->headers->get('X-Islandora-Args');
 
-	// Reject messages that try to set loglevel. We have to force
-	// it to be '-loglevel error'. Anything more verbose caues
-	// issues with large files.
-	if (preg_match("/\-loglevel/", $args)) {
+        // Reject messages that try to set loglevel. We have to force
+        // it to be '-loglevel error'. Anything more verbose caues
+        // issues with large files.
+        if (preg_match("/\-loglevel/", $args)) {
             $this->log->error("Malformed request, don't try to set loglevel in X-Islandora-Args");
             return new Response(
                 "Malformed request, don't try to set loglevel in X-Islandora-Args",
                 400
             );
-	}
+        }
       
         // Add -loglevel error so large files can be processed.
         $args .= ' -loglevel error';

--- a/Homarus/src/Controller/HomarusController.php
+++ b/Homarus/src/Controller/HomarusController.php
@@ -126,7 +126,7 @@ class HomarusController
         // Reject messages that try to set loglevel. We have to force
         // it to be '-loglevel error'. Anything more verbose caues
         // issues with large files.
-        if (strpos($args, '-loglevel') !== FALSE) {
+        if (strpos($args, '-loglevel') !== false) {
             $this->log->error("Malformed request, don't try to set loglevel in X-Islandora-Args");
             return new Response(
                 "Malformed request, don't try to set loglevel in X-Islandora-Args",

--- a/Homarus/src/Controller/HomarusController.php
+++ b/Homarus/src/Controller/HomarusController.php
@@ -121,8 +121,11 @@ class HomarusController
                 "frag_keyframe+empty_moov ";
         }
 
-        // Arguments to ffmpeg command are sent as a custom header
+        // Arguments to ffmpeg command are sent as a custom header.
         $args = $request->headers->get('X-Islandora-Args');
+      
+        // Add -loglevel error so large files can be processed.
+        $args .= ' -loglevel error';
         $this->log->debug("X-Islandora-Args:", ['args' => $args]);
 
         $cmd_string = "$this->executable -i $source $args $cmd_params -f $format -";

--- a/Homarus/src/Controller/HomarusController.php
+++ b/Homarus/src/Controller/HomarusController.php
@@ -126,7 +126,7 @@ class HomarusController
         // Reject messages that try to set loglevel. We have to force
         // it to be '-loglevel error'. Anything more verbose caues
         // issues with large files.
-        if (preg_match("/\-loglevel/", $args)) {
+        if (strpos($args, '-loglevel') !== FALSE) {
             $this->log->error("Malformed request, don't try to set loglevel in X-Islandora-Args");
             return new Response(
                 "Malformed request, don't try to set loglevel in X-Islandora-Args",

--- a/Homarus/src/Controller/HomarusController.php
+++ b/Homarus/src/Controller/HomarusController.php
@@ -23,7 +23,6 @@ class HomarusController
    */
     protected $cmd;
 
-
   /**
    * @var \Monolog\Logger
    */
@@ -123,6 +122,17 @@ class HomarusController
 
         // Arguments to ffmpeg command are sent as a custom header.
         $args = $request->headers->get('X-Islandora-Args');
+
+	// Reject messages that try to set loglevel. We have to force
+	// it to be '-loglevel error'. Anything more verbose caues
+	// issues with large files.
+	if (preg_match("/\-loglevel/", $args)) {
+            $this->log->error("Malformed request, don't try to set loglevel in X-Islandora-Args");
+            return new Response(
+                "Malformed request, don't try to set loglevel in X-Islandora-Args",
+                400
+            );
+	}
       
         // Add -loglevel error so large files can be processed.
         $args .= ' -loglevel error';

--- a/Homarus/tests/Islandora/Homarus/Tests/HomarusControllerTest.php
+++ b/Homarus/tests/Islandora/Homarus/Tests/HomarusControllerTest.php
@@ -192,6 +192,24 @@ class HomarusControllerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(400, $response->getStatusCode(), "Response must return 400");
     }
 
+    public function testFailOnSettingLogLevel() {
+        $controller = $this->getDefaultController();
+        $mock_fedora_response = $this->getMockFedoraResource();
+
+        $request = Request::create(
+            "/",
+            "GET"
+        );
+        $request->headers->set('Authorization', 'some_token');
+        $request->headers->set('Apix-Ldp-Resource', 'http://localhost:8080/fcrepo/rest/foo');
+        $request->headers->set('Accept', 'video/mp4');
+        $request->headers->set('X-Islandora-Args', '-vn -ar 44100 -loglevel debug -ac 2 -ab 192');
+        $request->attributes->set('fedora_resource', $mock_fedora_response);
+
+        $response = $controller->convert($request);
+        $this->assertEquals(400, $response->getStatusCode(), "Response must return 400");
+    }
+
     private function getDefaultController()
     {
         // Mock a CmdExecuteService.

--- a/Homarus/tests/Islandora/Homarus/Tests/HomarusControllerTest.php
+++ b/Homarus/tests/Islandora/Homarus/Tests/HomarusControllerTest.php
@@ -192,7 +192,8 @@ class HomarusControllerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(400, $response->getStatusCode(), "Response must return 400");
     }
 
-    public function testFailOnSettingLogLevel() {
+    public function testFailOnSettingLogLevel()
+    {
         $controller = $this->getDefaultController();
         $mock_fedora_response = $this->getMockFedoraResource();
 


### PR DESCRIPTION
**GitHub Issue**: Part of the fix for https://github.com/Islandora/documentation/issues/1278

# What does this Pull Request do?

Adds `-loglevel error` to every `ffmpeg` command so that large files can be processed. 

# How should this be tested?

See https://github.com/Islandora/documentation/issues/1278

# Interested parties
@Islandora/8-x-committers @kayakr @antbrown