### PR TITLE
Container name

### DIFF
--- a/Gemini/src/Controller/GeminiController.php
+++ b/Gemini/src/Controller/GeminiController.php
@@ -76,9 +76,11 @@ class GeminiController
             );
         }
 
+        $container_name = $request->headers->get('container-name', '');
+
         try {
             return new Response(
-                $this->urlMinter->mint($uuid),
+                $this->urlMinter->mint($uuid, $container_name),
                 200
             );
         } catch (\InvalidArgumentException $e) {

--- a/Gemini/src/Controller/GeminiController.php
+++ b/Gemini/src/Controller/GeminiController.php
@@ -76,11 +76,11 @@ class GeminiController
             );
         }
 
-        $fedora_container_url = $request->headers->get('fedora-container-url', '');
+        $islandora_fedora_endpoint = $request->headers->get('X-Islandora-Fedora-Endpoint', '');
 
         try {
             return new Response(
-                $this->urlMinter->mint($uuid, $fedora_container_url),
+                $this->urlMinter->mint($uuid, $islandora_fedora_endpoint),
                 200
             );
         } catch (\InvalidArgumentException $e) {

--- a/Gemini/src/Controller/GeminiController.php
+++ b/Gemini/src/Controller/GeminiController.php
@@ -76,11 +76,11 @@ class GeminiController
             );
         }
 
-        $container_name = $request->headers->get('container-name', '');
+        $fedora_container_url = $request->headers->get('fedora-container-url', '');
 
         try {
             return new Response(
-                $this->urlMinter->mint($uuid, $container_name),
+                $this->urlMinter->mint($uuid, $fedora_container_url),
                 200
             );
         } catch (\InvalidArgumentException $e) {

--- a/Gemini/src/UrlMinter/UrlMinter.php
+++ b/Gemini/src/UrlMinter/UrlMinter.php
@@ -10,19 +10,10 @@ namespace Islandora\Gemini\UrlMinter;
 
 class UrlMinter implements UrlMinterInterface
 {
-    protected $base_url;
-
-    public function __construct(
-        $base_url
-    ) {
-        $trimmed = trim($base_url);
-        $this->base_url = rtrim($trimmed, '/') . '/';
-    }
-
     /**
      * {@inheritdoc}
      */
-    public function mint($context, $container_name)
+    public function mint($context, $fedora_container_url)
     {
         if (strlen($context) < 8) {
             throw new \InvalidArgumentException(
@@ -34,12 +25,7 @@ class UrlMinter implements UrlMinterInterface
         $segments = str_split(substr($context, 0, 8), 2);
 
         $path = implode("/", $segments) . "/$context";
-
-        if (!empty($container_name)) {
-            $minted_url = $this->base_url . $container_name . '/' . $path;
-        } else {
-            $minted_url = $this->base_url . $path;
-        }
+        $minted_url = $fedora_container_url . '/' . $path;
 
         return $minted_url;
     }

--- a/Gemini/src/UrlMinter/UrlMinter.php
+++ b/Gemini/src/UrlMinter/UrlMinter.php
@@ -13,7 +13,7 @@ class UrlMinter implements UrlMinterInterface
     /**
      * {@inheritdoc}
      */
-    public function mint($context, $fedora_container_url)
+    public function mint($context, $islandora_fedora_endpoint)
     {
         if (strlen($context) < 8) {
             throw new \InvalidArgumentException(
@@ -22,10 +22,11 @@ class UrlMinter implements UrlMinterInterface
             );
         }
 
+        $islandora_fedora_endpoint = rtrim($islandora_fedora_endpoint, "/");
         $segments = str_split(substr($context, 0, 8), 2);
 
         $path = implode("/", $segments) . "/$context";
-        $minted_url = $fedora_container_url . '/' . $path;
+        $minted_url = $islandora_fedora_endpoint . '/' . $path;
 
         return $minted_url;
     }

--- a/Gemini/src/UrlMinter/UrlMinter.php
+++ b/Gemini/src/UrlMinter/UrlMinter.php
@@ -22,7 +22,7 @@ class UrlMinter implements UrlMinterInterface
     /**
      * {@inheritdoc}
      */
-    public function mint($context)
+    public function mint($context, $container_name)
     {
         if (strlen($context) < 8) {
             throw new \InvalidArgumentException(
@@ -35,6 +35,12 @@ class UrlMinter implements UrlMinterInterface
 
         $path = implode("/", $segments) . "/$context";
 
-        return $this->base_url . $path;
+        if (!empty($container_name)) {
+            $minted_url = $this->base_url . $container_name . '/' . $path;
+        } else {
+            $minted_url = $this->base_url . $path;
+        }
+
+        return $minted_url;
     }
 }

--- a/Gemini/src/UrlMinter/UrlMinterInterface.php
+++ b/Gemini/src/UrlMinter/UrlMinterInterface.php
@@ -14,7 +14,8 @@ interface UrlMinterInterface
      * Mints a new uri from an arbitrary input.
      *
      * @param $context
+     * @param $container_name
      * @return string
      */
-    public function mint($context);
+    public function mint($context, $container_name);
 }

--- a/Gemini/src/UrlMinter/UrlMinterInterface.php
+++ b/Gemini/src/UrlMinter/UrlMinterInterface.php
@@ -14,8 +14,8 @@ interface UrlMinterInterface
      * Mints a new uri from an arbitrary input.
      *
      * @param $context
-     * @param $container_name
+     * @param $fedora_container_url
      * @return string
      */
-    public function mint($context, $container_name);
+    public function mint($context, $fedora_container_url);
 }

--- a/Gemini/src/UrlMinter/UrlMinterInterface.php
+++ b/Gemini/src/UrlMinter/UrlMinterInterface.php
@@ -14,8 +14,8 @@ interface UrlMinterInterface
      * Mints a new uri from an arbitrary input.
      *
      * @param $context
-     * @param $fedora_container_url
+     * @param $islandora_fedora_endpoint
      * @return string
      */
-    public function mint($context, $fedora_container_url);
+    public function mint($context, $islandora_fedora_endpoint);
 }

--- a/Gemini/src/app.php
+++ b/Gemini/src/app.php
@@ -18,7 +18,7 @@ $app['gemini.mapper'] = function ($app) {
     return new UrlMapper($app['db']);
 };
 $app['gemini.minter'] = function ($app) {
-    return new UrlMinter($app['crayfish.fedora_base_url']);
+    return new UrlMinter();
 };
 $app['gemini.controller'] = function ($app) {
     return new GeminiController(

--- a/Gemini/tests/Islandora/Gemini/Tests/UrlMinterTest.php
+++ b/Gemini/tests/Islandora/Gemini/Tests/UrlMinterTest.php
@@ -20,7 +20,7 @@ class UrlMinterTest extends \PHPUnit_Framework_TestCase
     public function testThrowsExceptionOnBlankString()
     {
         $minter = new UrlMinter("http://localhost:8080/fcrepo/rest");
-        $minter->mint("");
+        $minter->mint("", "");
     }
 
     /**
@@ -32,7 +32,7 @@ class UrlMinterTest extends \PHPUnit_Framework_TestCase
     public function testThrowsExceptionOnShortUUID()
     {
         $minter = new UrlMinter("http://localhost:8080/fcrepo/rest");
-        $minter->mint("abcd");
+        $minter->mint("abcd", "http://localhost:8080/fcrepo/rest/");
     }
 
     /**
@@ -42,10 +42,10 @@ class UrlMinterTest extends \PHPUnit_Framework_TestCase
     public function testHandlesMissingTrailingSlashInBaseUrl()
     {
         $missing_slash = new UrlMinter("http://localhost:8080/fcrepo/rest");
-        $first = $missing_slash->mint("5d150b3a-9d1b-437f-87a9-104b8cf15859");
+        $first = $missing_slash->mint("5d150b3a-9d1b-437f-87a9-104b8cf15859", "http://localhost:8080/fcrepo/rest/");
 
         $with_slash = new UrlMinter("http://localhost:8080/fcrepo/rest/");
-        $second = $with_slash->mint("5d150b3a-9d1b-437f-87a9-104b8cf15859");
+        $second = $with_slash->mint("5d150b3a-9d1b-437f-87a9-104b8cf15859", "http://localhost:8080/fcrepo/rest/");
 
         $this->assertTrue(
             strcmp($first, $second) == 0,
@@ -61,7 +61,7 @@ class UrlMinterTest extends \PHPUnit_Framework_TestCase
     {
         $minter = new UrlMinter("http://localhost:8080/fcrepo/rest");
         $expected = "http://localhost:8080/fcrepo/rest/5d/15/0b/3a/5d150b3a-9d1b-437f-87a9-104b8cf15859";
-        $actual = $minter->mint("5d150b3a-9d1b-437f-87a9-104b8cf15859");
+        $actual = $minter->mint("5d150b3a-9d1b-437f-87a9-104b8cf15859", "http://localhost:8080/fcrepo/rest/");
 
         $this->assertTrue(
             strcmp($actual, $expected) == 0,

--- a/Milliner/composer.json
+++ b/Milliner/composer.json
@@ -32,7 +32,7 @@
         ],
         "test": [
             "@check",
-	        "phpunit"
+	        "./vendor/bin/phpunit"
         ]
     },
     "config": {

--- a/Milliner/src/Controller/MillinerController.php
+++ b/Milliner/src/Controller/MillinerController.php
@@ -45,7 +45,7 @@ class MillinerController
         $token = $request->headers->get("Authorization", null);
         $jsonld_url = $request->headers->get("Content-Location");
         $islandora_fedora_endpoint = $request->headers->get("X-Islandora-Fedora-Endpoint");
-        
+
         if (empty($jsonld_url)) {
             return new Response("Expected JSONLD url in Content-Location header", 400);
         }
@@ -54,8 +54,8 @@ class MillinerController
             $response = $this->milliner->saveNode(
                 $uuid,
                 $jsonld_url,
-                $token,
-                $islandora_fedora_endpoint
+                $islandora_fedora_endpoint,
+                $token
             );
 
             return new Response(
@@ -146,8 +146,8 @@ class MillinerController
             $response = $this->milliner->saveExternal(
                 $uuid,
                 $external_url,
-                $token,
-                $islandora_fedora_endpoint
+                $islandora_fedora_endpoint,
+                $token
             );
 
             return new Response(

--- a/Milliner/src/Controller/MillinerController.php
+++ b/Milliner/src/Controller/MillinerController.php
@@ -44,7 +44,8 @@ class MillinerController
     {
         $token = $request->headers->get("Authorization", null);
         $jsonld_url = $request->headers->get("Content-Location");
-
+        $islandora_fedora_endpoint = $request->headers->get("X-Islandora-Fedora-Endpoint");
+        
         if (empty($jsonld_url)) {
             return new Response("Expected JSONLD url in Content-Location header", 400);
         }
@@ -53,7 +54,8 @@ class MillinerController
             $response = $this->milliner->saveNode(
                 $uuid,
                 $jsonld_url,
-                $token
+                $token,
+                $islandora_fedora_endpoint
             );
 
             return new Response(
@@ -134,6 +136,7 @@ class MillinerController
     {
         $token = $request->headers->get("Authorization", null);
         $external_url = $request->headers->get("Content-Location");
+        $islandora_fedora_endpoint = $request->headers->get("X-Islandora-Fedora-Endpoint");
 
         if (empty($external_url)) {
             return new Response("Expected external url in Content-Location header", 400);
@@ -143,7 +146,8 @@ class MillinerController
             $response = $this->milliner->saveExternal(
                 $uuid,
                 $external_url,
-                $token
+                $token,
+                $islandora_fedora_endpoint
             );
 
             return new Response(

--- a/Milliner/src/Service/MillinerService.php
+++ b/Milliner/src/Service/MillinerService.php
@@ -128,8 +128,8 @@ class MillinerService implements MillinerServiceInterface
             true
         );
 
-        $container_name = $this->getContainerName($jsonld, "http://purl.org/dc/terms/isPartOf");
-        $fedora_url = $this->gemini->mintFedoraUrl($uuid, $token, $container_name);
+        $fedora_container_url = "http://localhost:8080/fcrepo/rest/container_a";
+        $fedora_url = $this->gemini->mintFedoraUrl($uuid, $token, $fedora_container_url);
         
         $subject_url = $this->stripFormatJsonld ? $entity_url : $jsonld_url;
 
@@ -504,11 +504,10 @@ class MillinerService implements MillinerServiceInterface
         $token = null
     ) {
         // Mint a new Fedora URL.
-        $fedora_url = $this->gemini->mintFedoraUrl($uuid, $token, '');
+        $fedora_container_url = "http://localhost:8080/fcrepo/rest/container_a";
+        $fedora_url = $this->gemini->mintFedoraUrl($uuid, $token, $fedora_container_url);
 
-##        $headers = empty($token) ? [] : ['Authorization' => $token];
         $headers = empty($token) ? [] : ['Authorization' => $token];
-        
         $mimetype = $this->drupal->head(
             $external_url,
             ['headers' => $headers]
@@ -544,22 +543,5 @@ class MillinerService implements MillinerServiceInterface
         // Return the response from Fedora.
         return $response;
     }
-
-    /**
-     * Gets the container name!
-     *
-     * @param $jsonld
-     * @param $predicate
-     *
-     * @return mixed string
-     */
-    protected function getContainerName(array $jsonld, $predicate)
-    {
-        $container_name = '';
-        $container = $jsonld['@graph'][0][$predicate];
-        if(!empty($container)) {
-          $container_name = $container[0]["@value"];
-        }
-        return $container_name;
-    }    
+   
 }

--- a/Milliner/src/Service/MillinerService.php
+++ b/Milliner/src/Service/MillinerService.php
@@ -76,8 +76,8 @@ class MillinerService implements MillinerServiceInterface
     public function saveNode(
         $uuid,
         $jsonld_url,
-        $token = null,
-        $islandora_fedora_endpoint
+        $islandora_fedora_endpoint,
+        $token = null
     ) {
         $urls = $this->gemini->getUrls($uuid, $token);
 
@@ -86,8 +86,8 @@ class MillinerService implements MillinerServiceInterface
                 $uuid,
                 rtrim($jsonld_url, '?_format=jsonld'),
                 $jsonld_url,
-                $token,
-                $islandora_fedora_endpoint
+                $islandora_fedora_endpoint,
+                $token
             );
         } else {
             return $this->updateNode(
@@ -105,8 +105,8 @@ class MillinerService implements MillinerServiceInterface
      * @param string $uuid
      * @param string $entity_url
      * @param string $jsonld_url
-     * @param string $token
      * @param string $islandora_fedora_endpoint
+     * @param string $token
      *
      * @return \GuzzleHttp\Psr7\Response
      *
@@ -117,8 +117,8 @@ class MillinerService implements MillinerServiceInterface
         $uuid,
         $entity_url,
         $jsonld_url,
-        $token = null,
-        $islandora_fedora_endpoint
+        $islandora_fedora_endpoint,
+        $token = null
     ) {
         // Mint a new Fedora URL.
         $fedora_url = $this->gemini->mintFedoraUrl($uuid, $token, $islandora_fedora_endpoint);
@@ -505,8 +505,8 @@ class MillinerService implements MillinerServiceInterface
     public function saveExternal(
         $uuid,
         $external_url,
-        $token = null,
-        $islandora_fedora_endpoint
+        $islandora_fedora_endpoint,
+        $token = null
     ) {
         // Mint a new Fedora URL.
         $fedora_url = $this->gemini->mintFedoraUrl($uuid, $token, $islandora_fedora_endpoint);
@@ -547,5 +547,4 @@ class MillinerService implements MillinerServiceInterface
         // Return the response from Fedora.
         return $response;
     }
-   
 }

--- a/Milliner/src/Service/MillinerServiceInterface.php
+++ b/Milliner/src/Service/MillinerServiceInterface.php
@@ -12,6 +12,7 @@ interface MillinerServiceInterface
      * @param $uuid
      * @param $jsonld_url
      * @param $token
+     * @param $islandora_fedora_endpoint
      *
      * @throws \Exception
      *
@@ -20,7 +21,8 @@ interface MillinerServiceInterface
     public function saveNode(
         $uuid,
         $jsonld_url,
-        $token = null
+        $token = null,
+        $islandora_fedora_endpoint
     );
 
     /**
@@ -55,6 +57,7 @@ interface MillinerServiceInterface
      * @param $uuid
      * @param $external_url
      * @param $token
+     * @param $islandora_fedora_endpoint
      *
      * @throws \Exception
      *
@@ -63,6 +66,7 @@ interface MillinerServiceInterface
     public function saveExternal(
         $uuid,
         $external_url,
-        $token = null
+        $token = null,
+        $islandora_fedora_endpoint
     );
 }

--- a/Milliner/src/Service/MillinerServiceInterface.php
+++ b/Milliner/src/Service/MillinerServiceInterface.php
@@ -11,8 +11,8 @@ interface MillinerServiceInterface
     /**
      * @param $uuid
      * @param $jsonld_url
-     * @param $token
      * @param $islandora_fedora_endpoint
+     * @param $token
      *
      * @throws \Exception
      *
@@ -21,8 +21,8 @@ interface MillinerServiceInterface
     public function saveNode(
         $uuid,
         $jsonld_url,
-        $token = null,
-        $islandora_fedora_endpoint
+        $islandora_fedora_endpoint,
+        $token = null
     );
 
     /**
@@ -56,8 +56,8 @@ interface MillinerServiceInterface
     /**
      * @param $uuid
      * @param $external_url
-     * @param $token
      * @param $islandora_fedora_endpoint
+     * @param $token
      *
      * @throws \Exception
      *
@@ -66,7 +66,7 @@ interface MillinerServiceInterface
     public function saveExternal(
         $uuid,
         $external_url,
-        $token = null,
-        $islandora_fedora_endpoint
+        $islandora_fedora_endpoint,
+        $token = null
     );
 }

--- a/Milliner/tests/Islandora/Milliner/Tests/DeleteTest.php
+++ b/Milliner/tests/Islandora/Milliner/Tests/DeleteTest.php
@@ -11,13 +11,14 @@ use Monolog\Handler\NullHandler;
 use Monolog\Logger;
 use Prophecy\Argument;
 use Psr\Log\LoggerInterface;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class MillinerServiceTest
  * @package Islandora\Milliner\Tests
  * @coversDefaultClass \Islandora\Milliner\Service\MillinerService
  */
-class DeleteTest extends \PHPUnit_Framework_TestCase
+class DeleteTest extends TestCase
 {
     /**
      * @var LoggerInterface

--- a/Milliner/tests/Islandora/Milliner/Tests/MillinerControllerTest.php
+++ b/Milliner/tests/Islandora/Milliner/Tests/MillinerControllerTest.php
@@ -70,6 +70,7 @@ class MillinerControllerTest extends TestCase
             [],
             [
                 'HTTP_AUTHORIZATION' => 'Bearer islandora',
+                'X-Islandora-Fedora-Endpoint' => 'http://localhost:8080/fcrepo/rest/',
                 'HTTP_CONTENT_LOCATION' => 'http://localhost:8000/node/1?_format=jsonld',
             ]
         );
@@ -124,6 +125,7 @@ class MillinerControllerTest extends TestCase
             [],
             [
                 'HTTP_AUTHORIZATION' => 'Bearer islandora',
+                'X-Islandora-Fedora-Endpoint' => 'http://localhost:8080/fcrepo/rest/',
                 'HTTP_CONTENT_LOCATION' => 'http://localhost:8000/sites/default/files/1.jpg',
             ]
         );
@@ -151,7 +153,11 @@ class MillinerControllerTest extends TestCase
             ['uuid' => $uuid],
             [],
             [],
-            ['HTTP_AUTHORIZATION' => 'Bearer islandora']
+            [
+                'HTTP_AUTHORIZATION' => 'Bearer islandora',
+                'X-Islandora-Fedora-Endpoint' => 'http://localhost:8080/fcrepo/rest/',
+
+            ]
         );
         $response = $controller->saveNode($uuid, $request);
         $status = $response->getStatusCode();
@@ -204,7 +210,10 @@ class MillinerControllerTest extends TestCase
             ['uuid' => $uuid],
             [],
             [],
-            ['HTTP_AUTHORIZATION' => 'Bearer islandora']
+            [
+                'HTTP_AUTHORIZATION' => 'Bearer islandora',
+                'X-Islandora-Fedora-Endpoint' => 'http://localhost:8080/fcrepo/rest/',
+            ]
         );
         $response = $controller->saveExternal($uuid, $request);
         $status = $response->getStatusCode();
@@ -236,6 +245,7 @@ class MillinerControllerTest extends TestCase
             [],
             [
                 'HTTP_AUTHORIZATION' => 'Bearer islandora',
+                'X-Islandora-Fedora-Endpoint' => 'http://localhost:8080/fcrepo/rest/',
                 'HTTP_CONTENT_LOCATION' => 'http://localhost:8000/node/1?_format=jsonld',
             ]
         );
@@ -260,6 +270,7 @@ class MillinerControllerTest extends TestCase
             [],
             [
                 'HTTP_AUTHORIZATION' => 'Bearer islandora',
+                'X-Islandora-Fedora-Endpoint' => 'http://localhost:8080/fcrepo/rest/',
                 'HTTP_CONTENT_LOCATION' => 'http://localhost:8000/node/1?_format=jsonld',
             ]
         );
@@ -349,6 +360,7 @@ class MillinerControllerTest extends TestCase
             [],
             [
                 'HTTP_AUTHORIZATION' => 'Bearer islandora',
+                'X-Islandora-Fedora-Endpoint' => 'http://localhost:8080/fcrepo/rest/',
                 'HTTP_CONTENT_LOCATION' => 'http://localhost:8000/sites/default/files/1.jpeg',
             ]
         );
@@ -373,6 +385,7 @@ class MillinerControllerTest extends TestCase
             [],
             [
                 'HTTP_AUTHORIZATION' => 'Bearer islandora',
+                'X-Islandora-Fedora-Endpoint' => 'http://localhost:8080/fcrepo/rest/',
                 'HTTP_CONTENT_LOCATION' => 'http://localhost:8000/sites/default/files/1.jpeg',
             ]
         );

--- a/Milliner/tests/Islandora/Milliner/Tests/MillinerControllerTest.php
+++ b/Milliner/tests/Islandora/Milliner/Tests/MillinerControllerTest.php
@@ -10,13 +10,14 @@ use Prophecy\Argument;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class MillinerControllerTest
  * @package Islandora\Milliner\Tests
  * @coversDefaultClass \Islandora\Milliner\Controller\MillinerController
  */
-class MillinerControllerTest extends \PHPUnit_Framework_TestCase
+class MillinerControllerTest extends TestCase
 {
     /**
      * @var LoggerInterface
@@ -44,13 +45,13 @@ class MillinerControllerTest extends \PHPUnit_Framework_TestCase
     {
         // Wire up a controller.
         $milliner = $this->prophesize(MillinerServiceInterface::class);
-        $milliner->saveNode(Argument::any(), Argument::any(), Argument::any())
+        $milliner->saveNode(Argument::any(), Argument::any(), Argument::any(), Argument::any())
             ->willThrow(new \Exception("Forbidden", 403));
         $milliner->saveMedia(Argument::any(), Argument::any(), Argument::any())
             ->willThrow(new \Exception("Forbidden", 403));
         $milliner->deleteNode(Argument::any(), Argument::any())
             ->willThrow(new \Exception("Forbidden", 403));
-        $milliner->saveExternal(Argument::any(), Argument::any(), Argument::any())
+        $milliner->saveExternal(Argument::any(), Argument::any(), Argument::any(), Argument::any())
             ->willThrow(new \Exception("Forbidden", 403));
         $milliner = $milliner->reveal();
 
@@ -220,7 +221,7 @@ class MillinerControllerTest extends \PHPUnit_Framework_TestCase
     public function testSaveNodeReturnsSuccessOnSuccess()
     {
         $milliner = $this->prophesize(MillinerServiceInterface::class);
-        $milliner->saveNode(Argument::any(), Argument::any(), Argument::any())
+        $milliner->saveNode(Argument::any(), Argument::any(), Argument::any(), Argument::any())
             ->willReturn(new Response(201));
         $milliner = $milliner->reveal();
         $controller = new MillinerController($milliner, $this->logger);
@@ -246,7 +247,7 @@ class MillinerControllerTest extends \PHPUnit_Framework_TestCase
         );
 
         $milliner = $this->prophesize(MillinerServiceInterface::class);
-        $milliner->saveNode(Argument::any(), Argument::any(), Argument::any())
+        $milliner->saveNode(Argument::any(), Argument::any(), Argument::any(), Argument::any())
             ->willReturn(new Response(204));
         $milliner = $milliner->reveal();
         $controller = new MillinerController($milliner, $this->logger);
@@ -333,7 +334,7 @@ class MillinerControllerTest extends \PHPUnit_Framework_TestCase
     public function testSaveExternalReturnsSuccessOnSuccess()
     {
         $milliner = $this->prophesize(MillinerServiceInterface::class);
-        $milliner->saveExternal(Argument::any(), Argument::any(), Argument::any())
+        $milliner->saveExternal(Argument::any(), Argument::any(), Argument::any(), Argument::any())
             ->willReturn(new Response(201));
         $milliner = $milliner->reveal();
         $controller = new MillinerController($milliner, $this->logger);
@@ -359,7 +360,7 @@ class MillinerControllerTest extends \PHPUnit_Framework_TestCase
         );
 
         $milliner = $this->prophesize(MillinerServiceInterface::class);
-        $milliner->saveExternal(Argument::any(), Argument::any(), Argument::any())
+        $milliner->saveExternal(Argument::any(), Argument::any(), Argument::any(), Argument::any())
             ->willReturn(new Response(204));
         $milliner = $milliner->reveal();
         $controller = new MillinerController($milliner, $this->logger);

--- a/Milliner/tests/Islandora/Milliner/Tests/SaveExternalTest.php
+++ b/Milliner/tests/Islandora/Milliner/Tests/SaveExternalTest.php
@@ -53,7 +53,7 @@ class SaveExternalTest extends TestCase
     public function testSaveExternalThrowsOnMintError()
     {
         $gemini = $this->prophesize(GeminiClient::class);
-        $gemini->mintFedoraUrl(Argument::any(), Argument::any())
+        $gemini->mintFedoraUrl(Argument::any(), Argument::any(), Argument::any())
             ->willThrow(
                 new RequestException(
                     "Unauthorized",
@@ -81,6 +81,7 @@ class SaveExternalTest extends TestCase
         $milliner->saveExternal(
             "9541c0c1-5bee-4973-a9d0-e55c1658bc81",
             'http://localhost:8000/sites/default/files/2017-07/sample_0.jpeg',
+            "http://localhost:8080/fcrepo/rest/",
             "Bearer islandora"
         );
     }
@@ -95,7 +96,7 @@ class SaveExternalTest extends TestCase
     {
         $url = "http://localhost:8080/95/41/c0/c1/9541c0c1-5bee-4973-a9d0-e55c1658bc81";
         $gemini = $this->prophesize(GeminiClient::class);
-        $gemini->mintFedoraUrl(Argument::any(), Argument::any())
+        $gemini->mintFedoraUrl(Argument::any(), Argument::any(), Argument::any())
             ->willReturn($url);
         $gemini = $gemini->reveal();
 
@@ -125,6 +126,7 @@ class SaveExternalTest extends TestCase
         $milliner->saveExternal(
             "9541c0c1-5bee-4973-a9d0-e55c1658bc81",
             'http://localhost:8000/sites/default/files/2017-07/sample_0.jpeg',
+            "http://localhost:8080/fcrepo/rest/",
             "Bearer islandora"
         );
     }
@@ -139,7 +141,7 @@ class SaveExternalTest extends TestCase
     {
         $url = "http://localhost:8080/95/41/c0/c1/9541c0c1-5bee-4973-a9d0-e55c1658bc81";
         $gemini = $this->prophesize(GeminiClient::class);
-        $gemini->mintFedoraUrl(Argument::any(), Argument::any())
+        $gemini->mintFedoraUrl(Argument::any(), Argument::any(), Argument::any())
             ->willReturn($url);
         $gemini = $gemini->reveal();
 
@@ -165,6 +167,7 @@ class SaveExternalTest extends TestCase
         $milliner->saveExternal(
             "9541c0c1-5bee-4973-a9d0-e55c1658bc81",
             'http://localhost:8000/sites/default/files/2017-07/sample_0.jpeg',
+            "http://localhost:8080/fcrepo/rest/",
             "Bearer islandora"
         );
     }
@@ -179,7 +182,7 @@ class SaveExternalTest extends TestCase
     {
         $url = "http://localhost:8080/95/41/c0/c1/9541c0c1-5bee-4973-a9d0-e55c1658bc81";
         $gemini = $this->prophesize(GeminiClient::class);
-        $gemini->mintFedoraUrl(Argument::any(), Argument::any())
+        $gemini->mintFedoraUrl(Argument::any(), Argument::any(), Argument::any())
             ->willReturn($url);
         $gemini->saveUrls(Argument::any(), Argument::any(), Argument::any(), Argument::any())
             ->willThrow(
@@ -213,6 +216,7 @@ class SaveExternalTest extends TestCase
         $milliner->saveExternal(
             "9541c0c1-5bee-4973-a9d0-e55c1658bc81",
             'http://localhost:8000/sites/default/files/2017-07/sample_0.jpeg',
+            "http://localhost:8080/fcrepo/rest/",
             "Bearer islandora"
         );
     }

--- a/Milliner/tests/Islandora/Milliner/Tests/SaveMediaTest.php
+++ b/Milliner/tests/Islandora/Milliner/Tests/SaveMediaTest.php
@@ -10,13 +10,14 @@ use Islandora\Milliner\Service\MillinerService;
 use Monolog\Handler\NullHandler;
 use Monolog\Logger;
 use Prophecy\Argument;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class MillinerServiceTest
  * @package Islandora\Milliner\Tests
  * @coversDefaultClass \Islandora\Milliner\Service\MillinerService
  */
-class SaveMediaTest extends \PHPUnit_Framework_TestCase
+class SaveMediaTest extends TestCase
 {
     /**
      * @var LoggerInterface

--- a/Milliner/tests/Islandora/Milliner/Tests/SaveNodeTest.php
+++ b/Milliner/tests/Islandora/Milliner/Tests/SaveNodeTest.php
@@ -55,7 +55,7 @@ class SaveNodeTest extends TestCase
         $gemini = $this->prophesize(GeminiClient::class);
         $gemini->getUrls(Argument::any(), Argument::any())
             ->willReturn([]);
-        $gemini->mintFedoraUrl(Argument::any(), Argument::any())
+        $gemini->mintFedoraUrl(Argument::any(), Argument::any(), Argument::any())
             ->willThrow(
                 new RequestException(
                     "Unauthorized",
@@ -83,6 +83,7 @@ class SaveNodeTest extends TestCase
         $milliner->saveNode(
             "9541c0c1-5bee-4973-a9d0-e55c1658bc81",
             "http://localhost:8000/node/1?_format=jsonld",
+            "http://localhost:8080/fcrepo/rest/",
             "Bearer islandora"
         );
     }
@@ -100,7 +101,7 @@ class SaveNodeTest extends TestCase
         $gemini = $this->prophesize(GeminiClient::class);
         $gemini->getUrls(Argument::any(), Argument::any())
             ->willReturn([]);
-        $gemini->mintFedoraUrl(Argument::any(), Argument::any())
+        $gemini->mintFedoraUrl(Argument::any(), Argument::any(), Argument::any())
             ->willReturn($url);
         $gemini = $gemini->reveal();
 
@@ -132,6 +133,7 @@ class SaveNodeTest extends TestCase
         $milliner->saveNode(
             "9541c0c1-5bee-4973-a9d0-e55c1658bc81",
             "http://localhost:8000/node/1?_format=jsonld",
+            "http://localhost:8080/fcrepo/rest/",
             "Bearer islandora"
         );
     }
@@ -150,7 +152,7 @@ class SaveNodeTest extends TestCase
         $gemini = $this->prophesize(GeminiClient::class);
         $gemini->getUrls(Argument::any(), Argument::any())
             ->willReturn([]);
-        $gemini->mintFedoraUrl(Argument::any(), Argument::any())
+        $gemini->mintFedoraUrl(Argument::any(), Argument::any(), Argument::any())
             ->willReturn($url);
         $gemini = $gemini->reveal();
 
@@ -205,7 +207,7 @@ class SaveNodeTest extends TestCase
         $gemini = $this->prophesize(GeminiClient::class);
         $gemini->getUrls(Argument::any(), Argument::any())
             ->willReturn([]);
-        $gemini->mintFedoraUrl(Argument::any(), Argument::any())
+        $gemini->mintFedoraUrl(Argument::any(), Argument::any(), Argument::any())
             ->willReturn($url);
         $gemini->saveUrls(Argument::any(), Argument::any(), Argument::any(), Argument::any())
             ->willReturn(true);
@@ -239,6 +241,7 @@ class SaveNodeTest extends TestCase
         $response = $milliner->saveNode(
             "9541c0c1-5bee-4973-a9d0-e55c1658bc81",
             "http://localhost:8000/node/1?_format=jsonld",
+            "http://localhost:8080/fcrepo/rest/",
             "Bearer islandora"
         );
 
@@ -261,7 +264,7 @@ class SaveNodeTest extends TestCase
         $gemini = $this->prophesize(GeminiClient::class);
         $gemini->getUrls(Argument::any(), Argument::any())
             ->willReturn([]);
-        $gemini->mintFedoraUrl(Argument::any(), Argument::any())
+        $gemini->mintFedoraUrl(Argument::any(), Argument::any(), Argument::any())
             ->willReturn($url);
         $gemini->saveUrls(Argument::any(), Argument::any(), Argument::any(), Argument::any())
             ->willReturn(true);
@@ -295,6 +298,7 @@ class SaveNodeTest extends TestCase
         $response = $milliner->saveNode(
             "9541c0c1-5bee-4973-a9d0-e55c1658bc81",
             "http://localhost:8000/node/1?_format=jsonld",
+            "http://localhost:8080/fcrepo/rest/",
             "Bearer islandora"
         );
 
@@ -346,6 +350,7 @@ class SaveNodeTest extends TestCase
         $milliner->saveNode(
             "9541c0c1-5bee-4973-a9d0-e55c1658bc81",
             "http://localhost:8000/node/1?_format=jsonld",
+            "http://localhost:8080/fcrepo/rest/",
             "Bearer islandora"
         );
     }
@@ -403,6 +408,7 @@ class SaveNodeTest extends TestCase
         $milliner->saveNode(
             "9541c0c1-5bee-4973-a9d0-e55c1658bc81",
             "http://localhost:8000/node/1?_format=jsonld",
+            "http://localhost:8080/fcrepo/rest/",
             "Bearer islandora"
         );
     }
@@ -460,6 +466,7 @@ class SaveNodeTest extends TestCase
         $milliner->saveNode(
             "9541c0c1-5bee-4973-a9d0-e55c1658bc81",
             "http://localhost:8000/node/1?_format=jsonld",
+            "http://localhost:8080/fcrepo/rest/",
             "Bearer islandora"
         );
     }
@@ -520,6 +527,7 @@ class SaveNodeTest extends TestCase
         $milliner->saveNode(
             "9541c0c1-5bee-4973-a9d0-e55c1658bc81",
             "http://localhost:8000/node/1?_format=jsonld",
+            "http://localhost:8080/fcrepo/rest/",
             "Bearer islandora"
         );
     }
@@ -580,6 +588,7 @@ class SaveNodeTest extends TestCase
         $response = $milliner->saveNode(
             "9541c0c1-5bee-4973-a9d0-e55c1658bc81",
             "http://localhost:8000/node/1?_format=jsonld",
+            "http://localhost:8080/fcrepo/rest/",
             "Bearer islandora"
         );
 
@@ -646,6 +655,7 @@ class SaveNodeTest extends TestCase
         $response = $milliner->saveNode(
             "9541c0c1-5bee-4973-a9d0-e55c1658bc81",
             "http://localhost:8000/node/1?_format=jsonld",
+            "http://localhost:8080/fcrepo/rest/",
             "Bearer islandora"
         );
 


### PR DESCRIPTION
** Please hold on from testing.  Will provide more info. **

**GitHub Issue**: (link)
Part of the work towards: https://github.com/Islandora/documentation/issues/926

# What does this Pull Request do?
This PR accepts fedora_end_point as header argument and uses it to create the fedora resource.

Dependency: https://github.com/Islandora/Alpaca/pull/65,https://github.com/Islandora/Crayfish-Commons/pull/36

## Additional Notes on testing:
Backup installed Gemini and Milliner
vagrant@claw:/var/www/html$ sudo cp -R Crayfish/Gemini/ ./
vagrant@claw:/var/www/html$ sudo cp -R Crayfish/Milliner/ ./

Delete Gemini and Milliner folders
vagrant@claw:/var/www/html/Crayfish$ rm -R Gemini
vagrant@claw:/var/www/html/Crayfish$ rm -R Milliner

Get the PR into a folder:
vagrant@claw:/var/www/html$ sudo mkdir CrayfishNew
vagrant@claw:/var/www/html/CrayfishNew$ sudo git clone https://github.com/Islandora/Crayfish
vagrant@claw:/var/www/html/CrayfishNew/Crayfish$ sudo git fetch origin pull/88/head:test
vagrant@claw:/var/www/html/CrayfishNew/Crayfish$ sudo git checkout test

Get the Gemini PR and install
vagrant@claw:/var/www/html/Crayfish$ sudo cp -R ../CrayfishNew/Crayfish/Gemini/ ./
vagrant@claw:/var/www/html/Crayfish/Gemini$ sudo cp /var/www/html/Gemini/syn-settings.xml ./
vagrant@claw:/var/www/html/Crayfish/Gemini/cfg$ sudo cp /var/www/html/Gemini/cfg/config.yaml ./

Testing Gemini:
vagrant@claw:/var/www/html/Crayfish$ sudo cp -R ../CrayfishNew/Crayfish/Milliner/ ./
vagrant@claw:/var/www/html/Crayfish/Milliner$ sudo cp ../../Milliner/syn-settings.xml ./
vagrant@claw:/var/www/html/Crayfish/Milliner/cfg$ sudo cp ../../../Milliner/cfg/config.yaml ./
vagrant@claw:/var/www/html/Crayfish/Milliner/cfg$ sudo cp ../../../Milliner/cfg/config.yaml ./

Replace 
/var/www/html/Crayfish/Milliner/vendor/islandora/crayfish-commons
With
https://github.com/Islandora/Crayfish-Commons/pull/36

Assuming we have a container named container_a, which can be created as below:
```
curl -v -H "Authorization: Bearer islandora" -H "fedora-container-url: http://localhost:8080/fcrepo/rest/container_a" -H "Content-Type: application/json" -d 'ab70127a-8579-4c17-af07-b3b1eceebb17' http://localhost:8000/gemini/
```

A gemini post request should return:
```
curl -v -H "Authorization: Bearer islandora" -H "X-Islandora-Fedora-Endpoint: http://localhost:8080/fcrepo/rest/container_a" -H “aaa: container_a“ -H "Content-Type: application/json"  -d 'ab70127a-8579-4c17-af07-b3b1eceebb17' http://localhost:8000/gemini/
```

```
< HTTP/1.1 200 OK
< Date: Mon, 09 Dec 2019 18:33:35 GMT
< Server: Apache/2.4.29 (Ubuntu)
< X-Powered-By: PHP/7.2.25-1+ubuntu18.04.1+deb.sury.org+1
< Cache-Control: no-cache, private
< Vary: Accept-Encoding
< Content-Length: 94
< Content-Type: text/html; charset=UTF-8
< 
* Connection #1 to host localhost left intact
http://localhost:8080/fcrepo/rest/container_a/ab/70/12/7a/ab70127a-8579-4c17-af07-b3b1eceebb17nat@natubuntu:~/vagrant/islandora-playbook$ 

```
