### PR TITLE
Hypercube: give pdftotext a real file path instead of stdin

### DIFF
--- a/Hypercube/src/Controller/HypercubeController.php
+++ b/Hypercube/src/Controller/HypercubeController.php
@@ -76,22 +76,66 @@ class HypercubeController
 
         $this->log->debug("Got Content-Type:", ['type' => $content_type]);
 
-        if ($content_type == 'application/pdf') {
-            $cmd_string = $this->pdftotext_executable . " $args - -";
-        } else {
-            $cmd_string = $this->tesseract_executable . " stdin stdout $args";
-        }
+        $tmp_path = null;
+        $data = $body;
 
-        $this->log->debug("Executing command:", ['cmd' => $cmd_string]);
-
-        // Return response.
         try {
+            if ($content_type == 'application/pdf') {
+                // Write the body to a temp file and give pdftotext a real path
+                // instead of stdin ("-"). Poppler's malformed-PDF recovery
+                // logic behaves very differently depending on whether its
+                // input is seekable: given a file path it fails fast; given a
+                // non-seekable pipe it can spin at ~100% CPU for the entire
+                // process, relying solely on the timeout wrapper to kill it.
+                // A real path also sidesteps the classic write-stdin-before
+                // -draining-stdout deadlock in CmdExecuteService::execute()
+                // for large outputs.
+                $tmp_path = tempnam(sys_get_temp_dir(), 'hypercube_');
+                if ($tmp_path === false) {
+                    throw new \RuntimeException('Unable to create temp file for pdftotext input.');
+                }
+
+                $tmp = fopen($tmp_path, 'wb');
+                if ($tmp === false) {
+                    throw new \RuntimeException('Unable to open temp file for pdftotext input.');
+                }
+
+                if (stream_copy_to_stream($body, $tmp) === false) {
+                    fclose($tmp);
+                    throw new \RuntimeException('Failed writing request body to temp file.');
+                }
+                fclose($tmp);
+                fclose($body);
+
+                $cmd_string = $this->pdftotext_executable . " $args " . escapeshellarg($tmp_path) . " -";
+                $data = null;
+            } else {
+                $cmd_string = $this->tesseract_executable . " stdin stdout $args";
+            }
+
+            $this->log->debug("Executing command:", ['cmd' => $cmd_string]);
+
+            $streamer = $this->cmd->execute($cmd_string, $data);
+
+            if ($tmp_path !== null) {
+                $streamer = function () use ($streamer, $tmp_path) {
+                    try {
+                        $streamer();
+                    } finally {
+                        @unlink($tmp_path);
+                    }
+                };
+            }
+
             return new StreamedResponse(
-                $this->cmd->execute($cmd_string, $body),
+                $streamer,
                 200,
                 ['Content-Type' => $request->headers->get('Accept') ?? 'text/plain']
             );
         } catch (\RuntimeException $e) {
+            if ($tmp_path !== null) {
+                @unlink($tmp_path);
+            }
             return new Response($e->getMessage(), 500);
         }
     }


### PR DESCRIPTION
## Summary

`Hypercube/src/Controller/HypercubeController.php`'s `pdftotext` invocation pipes the request body straight into `pdftotext`'s stdin/stdout (`pdftotext - -`). On a malformed/corrupt PDF, poppler's xref-repair logic behaves very differently depending on whether its input is seekable:

- **Real file path** (seekable): fails fast, ~8s, clean syntax-error exit.
- **stdin pipe** (non-seekable): spins at ~90-98% CPU for the entire duration, relying solely on the `timeout` wrapper (`crayfish-image#33` / `UNR2-323`) to kill it.

This was found while validating the `UNR2-323` timeout fix against the actual production file that caused the original incident (`artemisia_2.pdf`, 297MB) — it turned out to be genuinely corrupted (broken xref/trailer), not just large, and the ticket's own "zero CPU confirms deadlock" diagnosis didn't hold up under direct measurement (see UNR2-323 comments for the full writeup).

This PR writes the PDF request body to a temp file and gives `pdftotext` a real path instead of stdin, so corrupt files fail in ~8s instead of spinning for the full timeout window. The `timeout` wrapper stays in place as a backstop either way — this is a complementary optimization, not a replacement.

## Changes

- `Hypercube/src/Controller/HypercubeController.php`: for `application/pdf` requests only (tesseract/image path unchanged), stream the body to a temp file, invoke `pdftotext $args <tmpfile> -`, and clean up the temp file after streaming completes (or on error).
- Temp-file setup is wrapped in the same try/catch as command execution, so failures there (disk full, permission error) degrade the same way as any other failure in this method — clean `500`, not an unhandled fatal.

## Known tradeoff — worth a second look, not blocking

This changes crayfish's resource profile from pipe-streaming to buffering the full PDF to local disk (`/tmp`, which is the container's writable overlay layer — not a dedicated volume) before processing starts. Checked headroom on a live review-app crayfish pod: ~9GB free of 20GB, no `ephemeral-storage` request/limit set on the container today.

Given crayfish typically runs one pod per site with a single ActiveMQ consumer per queue (confirmed `ConsumerCount: 1` in testing), realistic concurrency is low — this isn't expected to be a problem in normal operation. But since there's currently no `ephemeral-storage` limit on the container, a burst of large concurrent files has no isolation: worst case is the *node's* shared disk filling up and kubelet disk-pressure-evicting other pods on the same node, rather than this pod failing cleanly on its own. Adding an `ephemeral-storage` request/limit (e.g. `512Mi`/`2Gi`) would convert that into a contained, cleanly-diagnosable pod eviction instead — cheap to add, no behavior change under normal load. Left out of this PR since it's not urgent given current usage patterns; flagging for reviewers to decide whether it's worth adding here or as a follow-up.

## Testing

Not yet validated end-to-end against a built image — needs a `crayfish-image` build/tag to test via the `unr-drupal` review app (stage cluster, PR #376) that was already used to validate `UNR2-323`. Suggested plan:
1. Known-good large/valid PDF (similar size, >64KB extractable text) — confirm still extracts successfully via the new file-based path (regression check).
2. Re-run the corrupt `artemisia_2.pdf` — confirm it now fails in ~8s instead of ~60s, and CPU stays low (no spin) via `ps` during the run.
3. Re-check ActiveMQ queue counters during both runs — no regression in queue draining.
